### PR TITLE
Refactor stop-loss create just 1 discrete order

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "solidity.packageDefaultDependenciesContractsDirectory": "src",
-  "solidity.packageDefaultDependenciesDirectory": "lib"
+  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "solidity.compileUsingRemoteVersion": "v0.8.26+commit.8a97fa7a"
 }

--- a/src/interfaces/IConditionalOrder.sol
+++ b/src/interfaces/IConditionalOrder.sol
@@ -10,9 +10,20 @@ import {IERC165} from "safe/interfaces/IERC165.sol";
  * @author CoW Protocol Developers + mfw78 <mfw78@rndlabs.xyz>
  */
 interface IConditionalOrder {
+    
     /// @dev This error is returned by the `getTradeableOrder` function if the order condition is not met.
     ///      A parameter of `string` type is included to allow the caller to specify the reason for the failure.
     error OrderNotValid(string);
+
+    // --- errors specific for polling
+    // Signal to a watch tower that polling should be attempted again.
+    error PollTryNextBlock(string reason);
+    // Signal to a watch tower that polling should be attempted again at a specific block number.
+    error PollTryAtBlock(uint256 blockNumber, string reason);
+    // Signal to a watch tower that polling should be attempted again at a specific epoch (unix timestamp).
+    error PollTryAtEpoch(uint256 timestamp, string reason);
+    // Signal to a watch tower that the conditional order should not be polled again (delete).
+    error PollNever(string reason);
 
     /**
      * @dev This struct is used to uniquely identify a conditional order for an owner.

--- a/src/types/GoodAfterTime.sol
+++ b/src/types/GoodAfterTime.sol
@@ -62,7 +62,7 @@ contract GoodAfterTime is BaseConditionalOrder {
 
         // Don't allow the order to be placed before it becomes valid.
         if (!(block.timestamp >= data.startTime)) {
-            revert IConditionalOrder.OrderNotValid(TOO_EARLY);
+            revert IConditionalOrder.PollTryAtEpoch(data.startTime, TOO_EARLY);
         }
 
         // Require that the sell token balance is above the minimum.
@@ -82,7 +82,7 @@ contract GoodAfterTime is BaseConditionalOrder {
 
             // Don't allow the order to be placed if the buyAmount is less than the minimum out.
             if (!(buyAmount >= (_expectedOut * (Utils.MAX_BPS - p.allowedSlippage)) / Utils.MAX_BPS)) {
-                revert IConditionalOrder.OrderNotValid(PRICE_CHECKER_FAILED);
+                revert IConditionalOrder.PollTryNextBlock(PRICE_CHECKER_FAILED);
             }
         }
 

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -13,6 +13,8 @@ string constant ORACLE_INVALID_PRICE = "oracle invalid price";
 string constant ORACLE_STALE_PRICE = "oracle stale price";
 /// @dev The strike price has not been reached
 string constant STRIKE_NOT_REACHED = "strike not reached";
+/// @dev The order is not valid anymore
+string constant ORDER_EXPIRED = "order expired";
 
 /**
  * @title StopLoss conditional order
@@ -34,7 +36,7 @@ contract StopLoss is BaseConditionalOrder {
      * @param receiver: The account that should receive the proceeds of the trade
      * @param isSellOrder: Whether this is a sell or buy order
      * @param isPartiallyFillable: Whether solvers are allowed to only fill a fraction of the order (useful if exact sell or buy amount isn't know at time of placement)
-     * @param validityBucketSeconds: How long the order will be valid. E.g. if the validityBucket is set to 15 minutes and the order is placed at 00:08, it will be valid until 00:15
+     * @param validTo: The UNIX timestamp that sets how long the order will be valid for
      * @param sellTokenPriceOracle: A chainlink-like oracle returning the current sell token price in a given numeraire
      * @param buyTokenPriceOracle: A chainlink-like oracle returning the current buy token price in the same numeraire
      * @param strike: The exchange rate (denominated in sellToken/buyToken) which triggers the StopLoss order if the oracle price falls below. Specified in base / quote with 18 decimals.
@@ -49,7 +51,7 @@ contract StopLoss is BaseConditionalOrder {
         address receiver;
         bool isSellOrder;
         bool isPartiallyFillable;
-        uint32 validityBucketSeconds;
+        uint32 validTo;
         IAggregatorV3Interface sellTokenPriceOracle;
         IAggregatorV3Interface buyTokenPriceOracle;
         int256 strike;
@@ -65,6 +67,11 @@ contract StopLoss is BaseConditionalOrder {
         Data memory data = abi.decode(staticInput, (Data));
         // scope variables to avoid stack too deep error
         {
+            /// @dev Guard against expired orders
+            if (data.validTo < block.timestamp) {
+                revert IConditionalOrder.OrderNotValid(ORDER_EXPIRED);
+            }
+
             (, int256 basePrice,, uint256 sellUpdatedAt,) = data.sellTokenPriceOracle.latestRoundData();
             (, int256 quotePrice,, uint256 buyUpdatedAt,) = data.buyTokenPriceOracle.latestRoundData();
 
@@ -100,7 +107,7 @@ contract StopLoss is BaseConditionalOrder {
             data.receiver,
             data.sellAmount,
             data.buyAmount,
-            Utils.validToBucket(data.validityBucketSeconds),
+            data.validTo,
             data.appData,
             0, // use zero fee for limit orders
             data.isSellOrder ? GPv2Order.KIND_SELL : GPv2Order.KIND_BUY,

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -80,7 +80,7 @@ contract StopLoss is BaseConditionalOrder {
                         && buyUpdatedAt >= block.timestamp - data.maxTimeSinceLastOracleUpdate
                 )
             ) {
-                revert IConditionalOrder.OrderNotValid(ORACLE_STALE_PRICE);
+                revert IConditionalOrder.PollTryNextBlock(ORACLE_STALE_PRICE);
             }
 
             // Normalize the decimals for basePrice and quotePrice, scaling them to 18 decimals
@@ -90,7 +90,7 @@ contract StopLoss is BaseConditionalOrder {
 
             /// @dev Scale the strike price to 18 decimals.
             if (!(basePrice * SCALING_FACTOR / quotePrice <= data.strike)) {
-                revert IConditionalOrder.OrderNotValid(STRIKE_NOT_REACHED);
+                revert IConditionalOrder.PollTryNextBlock(STRIKE_NOT_REACHED);
             }
         }
 

--- a/src/types/StopLoss.sol
+++ b/src/types/StopLoss.sol
@@ -36,7 +36,7 @@ contract StopLoss is BaseConditionalOrder {
      * @param receiver: The account that should receive the proceeds of the trade
      * @param isSellOrder: Whether this is a sell or buy order
      * @param isPartiallyFillable: Whether solvers are allowed to only fill a fraction of the order (useful if exact sell or buy amount isn't know at time of placement)
-     * @param validTo: The UNIX timestamp that sets how long the order will be valid for
+     * @param validTo: The UNIX timestamp before which this order is valid
      * @param sellTokenPriceOracle: A chainlink-like oracle returning the current sell token price in a given numeraire
      * @param buyTokenPriceOracle: A chainlink-like oracle returning the current buy token price in the same numeraire
      * @param strike: The exchange rate (denominated in sellToken/buyToken) which triggers the StopLoss order if the oracle price falls below. Specified in base / quote with 18 decimals.

--- a/src/types/TradeAboveThreshold.sol
+++ b/src/types/TradeAboveThreshold.sol
@@ -45,7 +45,7 @@ contract TradeAboveThreshold is BaseConditionalOrder {
         uint256 balance = data.sellToken.balanceOf(owner);
         // Don't allow the order to be placed if the balance is less than the threshold.
         if (!(balance >= data.threshold)) {
-            revert IConditionalOrder.OrderNotValid(BALANCE_INSUFFICIENT);
+            revert IConditionalOrder.PollTryNextBlock(BALANCE_INSUFFICIENT);
         }
         // ensures that orders queried shortly after one another result in the same hash (to avoid spamming the orderbook)
         order = GPv2Order.Data(

--- a/test/ComposableCoW.gat.t.sol
+++ b/test/ComposableCoW.gat.t.sol
@@ -54,7 +54,7 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         vm.warp(currentTime);
 
         // should revert when the current time is before the start time
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, TOO_EARLY));
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.PollTryAtEpoch.selector, startTime, TOO_EARLY));
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -75,7 +75,12 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         deal(address(o.sellToken), address(safe1), currentBalance);
 
         // should revert when the current balance is below the minimum balance
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, BALANCE_INSUFFICIENT));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IConditionalOrder.OrderNotValid.selector,
+                BALANCE_INSUFFICIENT
+            )
+        );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(uint256(1e18)));
     }
 
@@ -105,7 +110,12 @@ contract ComposableCoWGatTest is BaseComposableCoWTest {
         // set the current balance
         deal(address(o.sellToken), address(safe1), o.minSellBalance);
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, PRICE_CHECKER_FAILED));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IConditionalOrder.PollTryNextBlock.selector,
+                PRICE_CHECKER_FAILED
+            )
+        );
         gat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), abi.encode(buyAmount));
     }
 

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -327,14 +327,20 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         );
     }
 
-    function test_strikePriceMet_fuzz(int256 sellTokenOraclePrice, int256 buyTokenOraclePrice, int256 strike) public {
+    function test_strikePriceMet_fuzz(
+        int256 sellTokenOraclePrice,
+        int256 buyTokenOraclePrice,
+        int256 strike,
+        uint32 validTo
+    ) public {
+        // 25 June 2023 18:40:51
+        vm.warp(1687718451);
+
+        vm.assume(validTo >= block.timestamp);
         vm.assume(buyTokenOraclePrice > 0);
         vm.assume(sellTokenOraclePrice > 0 && sellTokenOraclePrice <= type(int256).max / 10 ** 18);
         vm.assume(strike > 0);
         vm.assume(sellTokenOraclePrice * int256(10 ** 18) / buyTokenOraclePrice <= strike);
-
-        // 25 June 2023 18:40:51
-        vm.warp(1687718451);
 
         StopLoss.Data memory data = StopLoss.Data({
             sellToken: mockToken(SELL_TOKEN, DEFAULT_DECIMALS),
@@ -348,7 +354,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             receiver: address(0x0),
             isSellOrder: false,
             isPartiallyFillable: false,
-            validTo: type(uint32).max,
+            validTo: validTo,
             maxTimeSinceLastOracleUpdate: 15 minutes
         });
 
@@ -359,7 +365,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         assertEq(order.sellAmount, 1 ether);
         assertEq(order.buyAmount, 1 ether);
         assertEq(order.receiver, address(0x0));
-        assertEq(order.validTo, type(uint32).max);
+        assertEq(order.validTo, validTo);
         assertEq(order.appData, APP_DATA);
         assertEq(order.feeAmount, 0);
         assertEq(order.kind, GPv2Order.KIND_BUY);

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -287,7 +287,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
-    function test_OracleRevertOnExpiriedOrder_fuzz(
+    function test_OracleRevertOnExpiredOrder_fuzz(
         uint32 currentTime,
         uint32 validTo
     ) public {

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -63,7 +63,12 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
 
         createOrder(stopLoss, 0x0, abi.encode(data));
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IConditionalOrder.PollTryNextBlock.selector,
+                STRIKE_NOT_REACHED
+            )
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -98,7 +103,12 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: staleTime
         });
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, STRIKE_NOT_REACHED));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IConditionalOrder.PollTryNextBlock.selector,
+                STRIKE_NOT_REACHED
+            )
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
@@ -228,7 +238,12 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
             maxTimeSinceLastOracleUpdate: maxTimeSinceLastOracleUpdate
         });
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, ORACLE_STALE_PRICE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IConditionalOrder.PollTryNextBlock.selector,
+                ORACLE_STALE_PRICE
+            )
+        );
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 

--- a/test/ComposableCoW.stoploss.t.sol
+++ b/test/ComposableCoW.stoploss.t.sol
@@ -287,7 +287,7 @@ contract ComposableCoWStopLossTest is BaseComposableCoWTest {
         stopLoss.getTradeableOrder(safe, address(0), bytes32(0), abi.encode(data), bytes(""));
     }
 
-    function test_OracleRevertOnExperiedOrder_fuzz(
+    function test_OracleRevertOnExpiriedOrder_fuzz(
         uint32 currentTime,
         uint32 validTo
     ) public {

--- a/test/ComposableCoW.tat.t.sol
+++ b/test/ComposableCoW.tat.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {ERC1271} from "safe/handler/extensible/SignatureVerifierMuxer.sol";
+
+import "./ComposableCoW.base.t.sol";
+
+import "../src/types/TradeAboveThreshold.sol";
+import {ConditionalOrdersUtilsLib as Utils} from "../src/types/ConditionalOrdersUtilsLib.sol";
+
+contract ComposableCoWTatTest is BaseComposableCoWTest {
+    using ComposableCoWLib for IConditionalOrder.ConditionalOrderParams[];
+    using SafeLib for Safe;
+
+    TradeAboveThreshold tat;
+
+    function setUp() public virtual override(BaseComposableCoWTest) {
+        super.setUp();
+
+        // deploy the TAT handler
+        tat = new TradeAboveThreshold();
+    }
+
+    /**
+     * @dev Fuzz test revert on balance too low
+     */
+    function test_getTradeableOrder_FuzzRevertBelowThreshold(uint256 currentBalance, uint256 threshold) public {
+        // Revert when the current balance is below the minimum balance
+        vm.assume(currentBalance < threshold);
+
+        TradeAboveThreshold.Data memory o = _tatTest();
+        o.threshold = threshold;
+
+        // set the current balance
+        deal(address(o.sellToken), address(safe1), currentBalance);
+
+        // should revert when the current balance is below the minimum balance
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IConditionalOrder.PollTryNextBlock.selector,
+                BALANCE_INSUFFICIENT
+            )
+        );
+        tat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(o), bytes(""));
+    }
+
+    function test_BalanceMet_fuzz(
+        address receiver,
+        uint256 threshold,
+        bytes32 appData,
+        uint256 currentBalance
+    ) public {
+        vm.assume(threshold > 0);
+        vm.assume(currentBalance >= threshold);
+
+        // Use same time data from stop loss test
+        vm.warp(1687718451);
+
+        TradeAboveThreshold.Data memory data = TradeAboveThreshold.Data({
+            sellToken: token0,
+            buyToken: token1,
+            receiver: receiver,
+            validityBucketSeconds: 15 minutes,
+            threshold: threshold,
+            appData: appData
+        });
+
+
+        // // set the current balance
+        deal(address(token0), address(safe1), currentBalance);
+
+        // This should not revert
+        GPv2Order.Data memory order =
+            tat.getTradeableOrder(address(safe1), address(0), bytes32(0), abi.encode(data), bytes(""));
+
+
+        assertEq(address(order.sellToken), address(token0));
+        assertEq(address(order.buyToken), address(token1));
+        assertEq(order.sellAmount, currentBalance);
+        assertEq(order.buyAmount, 1);
+        assertEq(order.receiver, receiver);
+        assertEq(order.validTo, 1687718700);
+        assertEq(order.appData, appData);
+        assertEq(order.feeAmount, 0);
+        assertEq(order.kind, GPv2Order.KIND_SELL);
+        assertEq(order.partiallyFillable, false);
+        assertEq(order.sellTokenBalance, GPv2Order.BALANCE_ERC20);
+        assertEq(order.buyTokenBalance, GPv2Order.BALANCE_ERC20);
+    }
+
+    // --- Helper functions ---
+
+    function _tatTest() internal view returns (TradeAboveThreshold.Data memory) {
+        return TradeAboveThreshold.Data({
+            sellToken: token0,
+            buyToken: token1,
+            receiver: address(0),
+            validityBucketSeconds: 15 minutes,
+            threshold: 200e18,
+            appData: keccak256("TradeAboveThreshold")
+        });
+    }
+}


### PR DESCRIPTION
# Description
- Avoid multiple discrete order creations for one stop-loss order creation.

# Changes
- [x] Replace the `validityBucketTime` parameter of stop loss data with constant `validTo`.

## How to test
1. Run the modified local test.
2. Try to create multiple discrete orders from the same stop-loss order using the deployed contract on sepolia: `0xe6CDbC068654C506424F7747357F51d0e7caB00e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling with new polling-related error types for better feedback on order processing.
	- Introduced a new expiration constant and improved clarity on order validity in the StopLoss contract.

- **Bug Fixes**
	- Updated revert statements to provide more contextual error messages related to order validity and pricing checks.

- **Tests**
	- Added new test cases to validate behavior around order expiration, improving coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->