### PR TITLE
feat(ComposableCoW): additive ConditionalOrderRegistered event

### DIFF
--- a/src/ComposableCoW.sol
+++ b/src/ComposableCoW.sol
@@ -49,6 +49,19 @@ contract ComposableCoW is ISafeSignatureVerifier {
     // An event emitted when a user sets their merkle root
     event MerkleRootSet(address indexed owner, bytes32 root, Proof proof);
     event ConditionalOrderCreated(address indexed owner, IConditionalOrder.ConditionalOrderParams params);
+    /// @dev Additive companion to `ConditionalOrderCreated`. Provides indexed `handler` and
+    ///      `ctx` (`= hash(params)`) for watch tower / indexer filtering at the RPC level
+    ///      (`eth_subscribe logs` can pass `topics: [hash, null, handlerAddr]` directly).
+    ///      Emitted alongside `ConditionalOrderCreated` in `create()` and
+    ///      `createWithContext()` whenever `dispatch == true`. The existing
+    ///      `ConditionalOrderCreated` signature is intentionally untouched so indexers
+    ///      keyed on its topic-0 hash continue to work.
+    event ConditionalOrderRegistered(
+        address indexed owner,
+        address indexed handler,
+        bytes32 indexed ctx,
+        IConditionalOrder.ConditionalOrderParams params
+    );
     event SwapGuardSet(address indexed owner, ISwapGuard swapGuard);
 
     // --- state
@@ -114,9 +127,14 @@ contract ComposableCoW is ISafeSignatureVerifier {
             revert InvalidHandler();
         }
 
-        singleOrders[msg.sender][hash(params)] = true;
+        bytes32 ctx = hash(params);
+        singleOrders[msg.sender][ctx] = true;
         if (dispatch) {
             emit ConditionalOrderCreated(msg.sender, params);
+            // additive companion event with `handler` and `ctx` indexed for
+            // RPC-level filtering. The existing `ConditionalOrderCreated` event is
+            // untouched (its topic-0 hash MUST NOT change — indexers depend on it).
+            emit ConditionalOrderRegistered(msg.sender, address(params.handler), ctx, params);
         }
     }
 

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -478,4 +478,61 @@ contract ComposableCoWTest is BaseComposableCoWTest {
             ERC1271.isValidSignature.selector
         );
     }
+
+    // --- additive `ConditionalOrderRegistered` event ---
+
+    // Re-declared here so `vm.expectEmit` can match it; `ComposableCoW.sol` defines the
+    // canonical signature.
+    event ConditionalOrderRegistered(
+        address indexed owner,
+        address indexed handler,
+        bytes32 indexed ctx,
+        IConditionalOrder.ConditionalOrderParams params
+    );
+
+    /// @dev `create()` emits BOTH events. The existing `ConditionalOrderCreated` is emitted
+    /// first (preserving its topic-0 order in receipts), then the new
+    /// `ConditionalOrderRegistered` with `owner`/`handler`/`ctx` indexed.
+    function test_create_emits_both_events_with_indexed_topics() public {
+        IConditionalOrder.ConditionalOrderParams memory params = getPassthroughOrder();
+        bytes32 expectedCtx = composableCow.hash(params);
+        address owner = address(safe1);
+
+        // First: existing event (signature unchanged).
+        vm.expectEmit(true, true, true, true);
+        emit ConditionalOrderCreated(owner, params);
+        // Second: new additive event with handler & ctx indexed.
+        vm.expectEmit(true, true, true, true);
+        emit ConditionalOrderRegistered(owner, address(params.handler), expectedCtx, params);
+
+        vm.prank(owner);
+        composableCow.create(params, true);
+    }
+
+    /// @dev `createWithContext()` also emits both events (it delegates to `create()`).
+    function test_createWithContext_emits_both_events() public {
+        IConditionalOrder.ConditionalOrderParams memory params = getPassthroughOrder();
+        bytes32 expectedCtx = composableCow.hash(params);
+        address owner = address(safe1);
+        bytes memory data = abi.encode(bytes32("ctxVal"));
+
+        vm.expectEmit(true, true, true, true);
+        emit ConditionalOrderCreated(owner, params);
+        vm.expectEmit(true, true, true, true);
+        emit ConditionalOrderRegistered(owner, address(params.handler), expectedCtx, params);
+
+        vm.prank(owner);
+        composableCow.createWithContext(params, testContextValue, data, true);
+    }
+
+    /// @dev Regression: the existing `ConditionalOrderCreated` event signature MUST NOT
+    /// change — its topic-0 hash is the keying value for every downstream indexer.
+    /// Pin the hash so any accidental signature edit fails the build.
+    function test_existing_ConditionalOrderCreated_signature_unchanged() public {
+        // Canonical signature per `IConditionalOrderGenerator` and `ComposableCoW`:
+        //   ConditionalOrderCreated(address,(address,bytes32,bytes))
+        bytes32 expectedTopic0 = keccak256("ConditionalOrderCreated(address,(address,bytes32,bytes))");
+        bytes32 actualTopic0 = ConditionalOrderCreated.selector;
+        assertEq(actualTopic0, expectedTopic0, "ConditionalOrderCreated topic-0 hash drifted");
+    }
 }


### PR DESCRIPTION
## What

Adds a new event alongside the existing `ConditionalOrderCreated`:

```solidity
event ConditionalOrderRegistered(
    address indexed owner,
    address indexed handler,
    bytes32 indexed ctx,
    IConditionalOrder.ConditionalOrderParams params
);
```

Emitted in `create()` (which `createWithContext()` already delegates to) immediately after the existing `ConditionalOrderCreated`, whenever `dispatch == true`. `ctx = hash(params)`.

The existing `ConditionalOrderCreated` event signature is **deliberately not modified** — its topic-0 hash is the keying value for every downstream indexer, and changing it (e.g. by adding a parameter) would break all of them silently.

## Why

The current `ConditionalOrderCreated(address indexed owner, ConditionalOrderParams params)` only indexes `owner`. Indexers wanting to filter by handler type (e.g. only TWAP orders, or only stop-loss orders) must:
1. Subscribe to every `ConditionalOrderCreated` log,
2. Decode `params` from the data portion,
3. Compare `params.handler` in user space.

That is wasteful at scale (Shepherd watches every chain it supports). With `handler` and `ctx` indexed, the same filter becomes one RPC-level `eth_subscribe logs` call with `topics: [hash, null, handlerAddr]`.

## Backward compatibility

- **Pure addition.** No existing event signature changes. No function selector changes. No public symbol removed/renamed.
- Indexers consuming `ConditionalOrderCreated` are entirely unaffected (same topic-0 hash, same payload, same order in the receipt — emitted first).
- Indexers can opt into the new event when they want indexed-handler filtering.
- A regression test pins `keccak256("ConditionalOrderCreated(address,(address,bytes32,bytes))")` against the live `.selector` so any accidental signature edit fails the build.

`IConditionalOrderGenerator.ConditionalOrderCreated` (in `src/interfaces/IConditionalOrder.sol`) is left untouched as instructed.

## Tests

3 new tests in `ComposableCoW.t.sol`:

- `test_create_emits_both_events_with_indexed_topics`
- `test_createWithContext_emits_both_events`
- `test_existing_ConditionalOrderCreated_signature_unchanged` (regression)

Full suite: 77/77 pass (74 pre-existing + 3 new), excluding the pre-existing `_invariant` and `test_simulate_fuzz` OOG flake.

## Closes

Addresses the "improved events".

