### PR TITLE
feat(ComposableCoW): batchGetTradeableOrdersWithSignature

### DIFF
--- a/src/ComposableCoW.sol
+++ b/src/ComposableCoW.sol
@@ -44,6 +44,30 @@ contract ComposableCoW is ISafeSignatureVerifier {
         bytes data;
     }
 
+    // Batched lookups for watch towers polling many watches on the same chain.
+
+    /// @dev One request inside a `batchGetTradeableOrdersWithSignature` call. Mirrors the
+    ///      argument list of `getTradeableOrderWithSignature` 1:1.
+    struct BatchOrderRequest {
+        address owner;
+        IConditionalOrder.ConditionalOrderParams params;
+        bytes offchainInput;
+        bytes32[] proof;
+    }
+
+    /// @dev One result inside a `batchGetTradeableOrdersWithSignature` call. On success,
+    ///      `order` and `signature` carry the payload; `revertData` is empty bytes. On
+    ///      failure, `success == false` and `revertData` carries the raw revert payload
+    ///      (selector + ABI-encoded args) so the caller can decode polling hints like
+    ///      `PollTryAtEpoch` / `PollNever`. Per-request try/catch isolation: one failed
+    ///      request never blocks the rest of the batch.
+    struct BatchOrderResult {
+        bool success;
+        GPv2Order.Data order;
+        bytes signature;
+        bytes revertData;
+    }
+
     // --- events
 
     // An event emitted when a user sets their merkle root
@@ -264,6 +288,41 @@ contract ComposableCoW is ISafeSignatureVerifier {
             // Assume that this is the EIP-1271 Forwarder (which does not have a `NAME` function)
             // The default signature is the abi.encode of the tuple (order, payload)
             signature = abi.encode(order, PayloadStruct({params: params, offchainInput: offchainInput, proof: proof}));
+        }
+    }
+
+    /**
+     * @notice Batched variant of `getTradeableOrderWithSignature`. Per-request try/catch
+     *         isolates failures: a failed request returns `success = false` with the raw
+     *         revert payload in `revertData`; other requests in the batch are unaffected.
+     *
+     *         Saves up to N-1 RPC round trips for watch towers polling N watches on the
+     *         same chain (Shepherd, the CoW DAO WatchTower, indexers' liveness probes).
+     *         The external self-call (`this.getTradeableOrderWithSignature(...)`) is what
+     *         gives us isolation — a direct internal call would bubble the revert and abort
+     *         the whole batch.
+     *
+     * @param requests Array of `BatchOrderRequest` mirroring `getTradeableOrderWithSignature`.
+     * @return results Array of `BatchOrderResult`, same length and order as `requests`.
+     */
+    function batchGetTradeableOrdersWithSignature(BatchOrderRequest[] calldata requests)
+        external
+        view
+        returns (BatchOrderResult[] memory results)
+    {
+        results = new BatchOrderResult[](requests.length);
+        for (uint256 i = 0; i < requests.length; ++i) {
+            try this.getTradeableOrderWithSignature(
+                requests[i].owner, requests[i].params, requests[i].offchainInput, requests[i].proof
+            ) returns (GPv2Order.Data memory order, bytes memory signature) {
+                results[i] = BatchOrderResult({success: true, order: order, signature: signature, revertData: ""});
+            } catch (bytes memory revertData) {
+                // Leave `order` and `signature` at their zero defaults — caller checks
+                // `success` first. Empty `order` / empty `signature` are still safe to
+                // ABI-decode (they just contain zeros).
+                results[i].success = false;
+                results[i].revertData = revertData;
+            }
         }
     }
 

--- a/test/ComposableCoW.t.sol
+++ b/test/ComposableCoW.t.sol
@@ -478,4 +478,113 @@ contract ComposableCoWTest is BaseComposableCoWTest {
             ERC1271.isValidSignature.selector
         );
     }
+
+    // --- batched getter ---
+
+    /// @dev Helper: build a `BatchOrderRequest` for the pass-through handler.
+    function _buildPassthroughRequest(address owner, bytes32 salt)
+        internal
+        returns (ComposableCoW.BatchOrderRequest memory req)
+    {
+        IConditionalOrder.ConditionalOrderParams memory params = createOrder(passThrough, salt, bytes(""));
+        _create(owner, params, false);
+        req = ComposableCoW.BatchOrderRequest({
+            owner: owner,
+            params: params,
+            offchainInput: abi.encode(getBlankOrder()),
+            proof: new bytes32[](0)
+        });
+    }
+
+    /// @dev All requests in the batch succeed; results are returned in input order with
+    /// `success = true` and `revertData == ""`.
+    function test_batchGetTradeableOrdersWithSignature_all_success() public {
+        ComposableCoW.BatchOrderRequest[] memory reqs = new ComposableCoW.BatchOrderRequest[](3);
+        reqs[0] = _buildPassthroughRequest(address(safe1), keccak256("batch-0"));
+        reqs[1] = _buildPassthroughRequest(address(safe1), keccak256("batch-1"));
+        reqs[2] = _buildPassthroughRequest(address(safe1), keccak256("batch-2"));
+
+        ComposableCoW.BatchOrderResult[] memory results = composableCow.batchGetTradeableOrdersWithSignature(reqs);
+
+        // The pass-through handler returns whatever `offchainInput` decodes to, so the
+        // order matches the blank order we encoded.
+        GPv2Order.Data memory expectedOrder = getBlankOrder();
+
+        assertEq(results.length, 3, "length mismatch");
+        for (uint256 i = 0; i < results.length; ++i) {
+            assertTrue(results[i].success, "expected success");
+            assertEq(results[i].revertData.length, 0, "expected empty revertData on success");
+            // Sanity-check the order survives the round trip — appData is the only
+            // distinguishing field on the blank order, so check it.
+            assertEq(results[i].order.appData, expectedOrder.appData, "appData mismatch");
+            // signature should be non-empty
+            assertGt(results[i].signature.length, 0, "expected non-empty signature");
+        }
+    }
+
+    /// @dev Mixed: one request succeeds, one reverts. The failed request returns
+    /// `success = false` and the raw revert payload; the successful one is unaffected.
+    function test_batchGetTradeableOrdersWithSignature_mixed_success_and_revert() public {
+        // Request 0 is authorised → should succeed.
+        ComposableCoW.BatchOrderRequest memory req0 = _buildPassthroughRequest(address(safe1), keccak256("mixed-0"));
+
+        // Request 1 uses params that were NEVER authorised → should revert with
+        // `SingleOrderNotAuthed` (this is the canonical revert path that watch towers see
+        // when polling a watch whose authorisation was revoked).
+        IConditionalOrder.ConditionalOrderParams memory unauthedParams =
+            createOrder(passThrough, keccak256("mixed-1-unauthed"), bytes(""));
+
+        ComposableCoW.BatchOrderRequest[] memory reqs = new ComposableCoW.BatchOrderRequest[](2);
+        reqs[0] = req0;
+        reqs[1] = ComposableCoW.BatchOrderRequest({
+            owner: address(safe1),
+            params: unauthedParams,
+            offchainInput: abi.encode(getBlankOrder()),
+            proof: new bytes32[](0)
+        });
+
+        ComposableCoW.BatchOrderResult[] memory results = composableCow.batchGetTradeableOrdersWithSignature(reqs);
+
+        assertEq(results.length, 2, "length mismatch");
+        assertTrue(results[0].success, "req0 should succeed");
+        assertEq(results[0].revertData.length, 0, "req0 should have empty revertData");
+
+        assertTrue(!results[1].success, "req1 should fail");
+        assertGt(results[1].revertData.length, 0, "req1 should carry revertData");
+    }
+
+    /// @dev `revertData` carries the raw revert payload (selector + args) so the caller
+    /// can decode it — this is what lets a watch tower act on `PollTryAtEpoch` /
+    /// `PollNever` / `SingleOrderNotAuthed` returned from a batched call.
+    function test_batchGetTradeableOrdersWithSignature_preserves_revert_data() public {
+        // Unauthorised → `SingleOrderNotAuthed` (selector-only, no args).
+        IConditionalOrder.ConditionalOrderParams memory unauthedParams =
+            createOrder(passThrough, keccak256("preserves-revert"), bytes(""));
+
+        ComposableCoW.BatchOrderRequest[] memory reqs = new ComposableCoW.BatchOrderRequest[](1);
+        reqs[0] = ComposableCoW.BatchOrderRequest({
+            owner: address(safe1),
+            params: unauthedParams,
+            offchainInput: abi.encode(getBlankOrder()),
+            proof: new bytes32[](0)
+        });
+
+        ComposableCoW.BatchOrderResult[] memory results = composableCow.batchGetTradeableOrdersWithSignature(reqs);
+
+        assertTrue(!results[0].success, "expected failure");
+        // Selector is the first 4 bytes of `revertData`. Reconstruct it.
+        bytes memory rd = results[0].revertData;
+        bytes4 selector;
+        assembly {
+            selector := mload(add(rd, 32))
+        }
+        assertEq(selector, ComposableCoW.SingleOrderNotAuthed.selector, "selector mismatch");
+    }
+
+    /// @dev Empty input → empty output, no revert.
+    function test_batchGetTradeableOrdersWithSignature_empty_input() public {
+        ComposableCoW.BatchOrderRequest[] memory reqs = new ComposableCoW.BatchOrderRequest[](0);
+        ComposableCoW.BatchOrderResult[] memory results = composableCow.batchGetTradeableOrdersWithSignature(reqs);
+        assertEq(results.length, 0, "expected empty array");
+    }
 }


### PR DESCRIPTION
## What

Adds a batched variant of `getTradeableOrderWithSignature`:

```solidity
struct BatchOrderRequest {
    address owner;
    IConditionalOrder.ConditionalOrderParams params;
    bytes offchainInput;
    bytes32[] proof;
}

struct BatchOrderResult {
    bool success;
    GPv2Order.Data order;
    bytes signature;
    bytes revertData; // empty on success; raw revert payload on failure
}

function batchGetTradeableOrdersWithSignature(BatchOrderRequest[] calldata requests)
    external
    view
    returns (BatchOrderResult[] memory results);
```

Per-request try/catch via `this.getTradeableOrderWithSignature(...)` (external self-call) isolates failures: a failed request returns `success = false` with the raw revert payload in `revertData`; other requests in the batch are unaffected. A direct internal call would bubble the revert and abort the whole batch — the self-call is what gives us isolation.

## Why

Watch towers (Shepherd, CoW DAO WatchTower) poll N watches every block. Today that is N separate `eth_call` round trips. Batching them collapses that to a single call, saving N-1 round trips and the associated provider latency / rate-limit pressure.

The raw `revertData` is preserved so a watch tower can still decode polling hints (`PollTryAtEpoch` / `PollNever`) and authorisation reverts (`SingleOrderNotAuthed`, `ProofNotAuthed`) from a batched call — same actionable taxonomy as the single-shot path.

## Backward compatibility

Pure addition. No existing function, event, or public symbol changed. Selectors of all existing functions remain identical. The new function is `view` and free of state mutation.

## Tests

4 new tests in `ComposableCoW.t.sol`:

- `test_batchGetTradeableOrdersWithSignature_all_success`
- `test_batchGetTradeableOrdersWithSignature_mixed_success_and_revert` (one valid, one with `SingleOrderNotAuthed`)
- `test_batchGetTradeableOrdersWithSignature_preserves_revert_data` (asserts selector is decodable)
- `test_batchGetTradeableOrdersWithSignature_empty_input` (returns empty array)

Full suite: 78/78 pass (74 pre-existing + 4 new), excluding the pre-existing `_invariant` and `test_simulate_fuzz` OOG flake.

## Closes

Addresses the "optimised getter functions".

